### PR TITLE
exports instead of function, deprecated buffer replace

### DIFF
--- a/utils/encode.js
+++ b/utils/encode.js
@@ -1,9 +1,16 @@
-function encodeToBase64(data){
-    let buff = new Buffer(data, 'utf8');
-    return buff.toString('base64');
+const encodeToBase64 = (json) => {
+    let buff = new Buffer.from(JSON.stringify(json), 'utf8');
+    buff = buff.toString('base64');
+    return buff;
 }
 
-function decodeFromBase64(data){
-    let buff = new Buffer(data, 'base64');
-    return buff.toString('utf-8');
+const decodeFromBase64 = (string) => {
+    let buff = new Buffer.from(string, 'base64');
+    buff = JSON.parse(buff.toString('utf-8'));
+    return buff;
+}
+
+module.exports = {
+    encodeToBase64,
+    decodeFromBase64
 }


### PR DESCRIPTION
hope the code matches your style otherwise feel free to adapt it.
I also changed the decode function so that input of base64 string with the content
```
{
    "json":{
        "name": "TESTNAME"
    }
}
```

will become
```
{
    "name": "TESTNAME"
}
```
in JSON format.

The function decode isn't used as of now.